### PR TITLE
MGDAPI-2420 - Create a release pipeline for the launcher - use Red Hat Jboss public image

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,6 @@
-FROM quay.io/openshiftio/rhel-base-jboss-jdk-8:latest
+#FROM quay.io/openshiftio/rhel-base-jboss-jdk-8:latest
+FROM registry.redhat.io/jboss-eap-7/eap73-openjdk8-runtime-openshift-rhel7:latest
+
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 
@@ -9,11 +11,15 @@ ENV LANG=en_US.UTF-8
 
 USER root
 
+RUN yum -y install git
+
 RUN chgrp -R 0 /opt/jboss &&\
     chmod -R g+rw /opt/jboss &&\
     find /opt/jboss -type d -exec chmod g+x {} + &&\
     git config --system user.name redhat-developers-launcher &&\
     git config --system user.email 45641108+redhat-developers-launcher@users.noreply.github.com
+
+RUN yum clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
 
 USER jboss
 


### PR DESCRIPTION
 use Red Hat Jboss public image

### Why
permissing issues with original image: quay.io/openshiftio/rhel-base-jboss-jdk-8:latest 

### Description

Dockerfile.deploy.rhel  - base image changed

### Checklist

- [ ] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-application/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-application/issues/new) and used it in the commit message.
- [ ] I have built the project locally prior to submission with `mvn clean install`.
- [ ] I kept a clean commit log (no unnecessary commits, no merge commits).
- [ ] I am happy with my contribution.
